### PR TITLE
Modifying copy to copy to a specific file name

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -2,7 +2,7 @@ class perforce::client() {
 
   wget::fetch { 'p4':
     source      => 'http://cdist2.perforce.com/perforce/r14.1/bin.linux26x86_64/p4',
-    destination => '/usr/bin',
+    destination => '/usr/bin/p4',
   } ->
   file { '/usr/bin/p4':
     mode => '0755',


### PR DESCRIPTION
wget fails that /usr/bin is just a directory otherwise.